### PR TITLE
Update Group.hs

### DIFF
--- a/src/Pipes/Group.hs
+++ b/src/Pipes/Group.hs
@@ -343,7 +343,7 @@ foldsM step begin done = go
             Right (a, p') -> do
                 x' <- step x a
                 foldM p' $! x'
-
+{-# INLINABLE foldsM #-}
 {- $reexports
     "Control.Monad.Trans.Class" re-exports 'lift'.
 


### PR DESCRIPTION
You omitted your standard 'Inlinable' for this kind of definition. Sure enough, adding it reduces the length of this program https://gist.github.com/michaelt/0f129511feb4ccc3786f from


    Michaels-Air:examples mthompso$ time ./chunkZ
    1000001

    real	0m3.572s

to

    Michaels-Air:examples mthompso$ time ./chunkZ
    1000001

    real	0m0.960s

You can test this indirectly just by compiling ChunkZ.hs as it is, and instead with the commented `foldsM_`, using it in line 20