### PR TITLE
Refactor Nix code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
-language: haskell
+language: nix
+script: nix-build release.nix

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,35 @@
-{ mkDerivation, base, doctest, free, lens-family-core, pipes
-, pipes-parse, stdenv, transformers
-}:
-mkDerivation {
-  pname = "pipes-group";
-  version = "1.0.11";
-  src = ./.;
-  libraryHaskellDepends = [
-    base free pipes pipes-parse transformers
-  ];
-  testHaskellDepends = [ base doctest lens-family-core ];
-  description = "Group streams into substreams";
-  license = stdenv.lib.licenses.bsd3;
-}
+let
+  fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
+
+  nixpkgs = fetchNixpkgs {
+    rev = "804060ff9a79ceb0925fe9ef79ddbf564a225d47";
+
+    sha256 = "01pb6p07xawi60kshsxxq1bzn8a0y4s5jjqvhkwps4f5xjmmwav3";
+
+    outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
+  };
+
+  readDirectory = import ./nix/readDirectory.nix;
+
+  config = {
+    packageOverrides = pkgs: {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides =
+          let
+            manualOverrides = haskellPackagesNew: haskellPackagesOld: {
+            };
+
+          in
+            pkgs.lib.composeExtensions (readDirectory ./nix) manualOverrides;
+      };
+    };
+  };
+
+  pkgs =
+    import nixpkgs { inherit config; };
+
+in
+  { inherit (pkgs.haskellPackages) pipes-group;
+
+    shell = (pkgs.haskell.lib.doBenchmark pkgs.haskellPackages.pipes-group).env;
+  }

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,49 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 fixed-output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+if (0 <= builtins.compareVersions builtins.nixVersion "1.12")
+
+# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+then (
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = outputSha256;
+  })
+
+# This hack should at least work for Nix 1.11
+else (
+  (rec {
+    tarball = import <nix/fetchurl.nix> {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
+    builtin-paths = import <nix/config.nix>;
+      
+    script = builtins.toFile "nixpkgs-unpacker" ''
+      "$coreutils/mkdir" "$out"
+      cd "$out"
+      "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+    '';
+
+    nixpkgs = builtins.derivation ({
+      name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+      builder = builtins.storePath builtin-paths.shell;
+
+      args = [ script ];
+
+      inherit tarball system;
+
+      tar       = builtins.storePath builtin-paths.tar;
+      gzip      = builtins.storePath builtin-paths.gzip;
+      coreutils = builtins.storePath builtin-paths.coreutils;
+    } // (if null == outputSha256 then { } else {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = outputSha256;
+    }));
+  }).nixpkgs)

--- a/nix/pipes-group.nix
+++ b/nix/pipes-group.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, doctest, free, lens-family-core, pipes
+, pipes-parse, stdenv, transformers
+}:
+mkDerivation {
+  pname = "pipes-group";
+  version = "1.0.11";
+  src = ./..;
+  libraryHaskellDepends = [
+    base free pipes pipes-parse transformers
+  ];
+  testHaskellDepends = [ base doctest lens-family-core ];
+  description = "Group streams into substreams";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/readDirectory.nix
+++ b/nix/readDirectory.nix
@@ -1,0 +1,14 @@
+directory:
+
+haskellPackagesNew: haskellPackagesOld:
+  let
+    haskellPaths = builtins.attrNames (builtins.readDir directory);
+
+    toKeyVal = file: {
+      name  = builtins.replaceStrings [ ".nix" ] [ "" ] file;
+
+      value = haskellPackagesNew.callPackage (directory + "/${file}") { };
+    };
+
+  in
+    builtins.listToAttrs (map toKeyVal haskellPaths)

--- a/release.nix
+++ b/release.nix
@@ -1,17 +1,5 @@
 let
-  config = {
-    packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override {
-        overrides = haskellPackagesNew: haskellPackagesOld: {
-          pipes-group = haskellPackagesNew.callPackage ./default.nix { };
-        };
-      };
-    };
-  };
-
-  pkgs =
-    import <nixpkgs> { inherit config; };
+  default = import ./default.nix;
 
 in
-  { inherit (pkgs.haskellPackages) pipes-group;
-  }
+  { inherit (default) pipes-group; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./release.nix).pipes-group.env
+(import ./default.nix).shell


### PR DESCRIPTION
This changes the Nix code to pin `nixpkgs` and to use `readDirectory` to
simplify updating dependencies