### PR TITLE
Build against `lens-family-core-2.1.0`

### DIFF
--- a/pipes-group.cabal
+++ b/pipes-group.cabal
@@ -46,5 +46,5 @@ Test-Suite tests
     Default-Language: Haskell2010
     Build-Depends:
         base             >= 4      && < 5  ,
-        lens-family-core              < 2.1,
+        lens-family-core              < 2.2,
         doctest          >= 0.9.12 && < 0.17


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/5182